### PR TITLE
Build in a container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
   - 5.4
   - 5.5


### PR DESCRIPTION
We don't need a full VM for our tests, a container is enough. This
change will enable that. This allows faster build times in travis, and
also that we're using less of their limited resources.