### PR TITLE
Move the satooshi/php-coveralls dependency to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,10 @@
     "name": "purplebooth/htmlstrip",
     "description": "Convert a small subset of html into something reasonable you can put in plain text email, or SMS.",
     "require": {
-      "php": ">=5.4.0",
-        "satooshi/php-coveralls": "^1.0"
+      "php": ">=5.4.0"
     },
     "require-dev": {
+        "satooshi/php-coveralls": "^1.0",
         "phpspec/phpspec": "^2.0.0",
         "henrikbjorn/phpspec-code-coverage": "^2.1",
         "sllh/php-cs-fixer-styleci-bridge": "^2.1"


### PR DESCRIPTION
The coveralls dependency should only need to be required in dev.

Please merge and tag a new version.