### PR TITLE
Add PHP 7.2 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       env: PREFIX="phpdbg -qrr "
     - php: 7.1
       env: PREFIX="phpdbg -qrr "
+    - php: 7.2
+      env: PREFIX="phpdbg -qrr "
     - php: nightly
       env: PREFIX="phpdbg -qrr "
 


### PR DESCRIPTION
This will ensure the tests run in PHP 7.2 so we can ensure future
compatibility.